### PR TITLE
Added brief explanation for git clone

### DIFF
--- a/git.html
+++ b/git.html
@@ -31,6 +31,10 @@
       <article>
         <ul>
           <li>
+            <a href="https://git-scm.com/docs/git-clone"><code>git clone &lt;repository&gt;</code></a>: Clones a repository from a remote source in a new directory &mdash; the command can be thought as a combination of both <code>git init</code> and <code>git branch [default_branch]</code>.
+          </li>
+
+          <li>
             <code>git init</code>
           </li>
 


### PR DESCRIPTION
This adds a brief note about `git clone` to the top of `git.html`.